### PR TITLE
Support for legacy PC5401 and some configuration options

### DIFF
--- a/evl-emu.py
+++ b/evl-emu.py
@@ -617,6 +617,8 @@ def msghandler_evl(readQueueNet, writeQueueNet, writeQueueSer, zones):
 						# Bug in certain DSC IT100 modules. Need to send partition number ahead of code.
 						# Ideally pyenvisalink would do this correctly by remembering the partition from the '900'.
 						writeQueueSer.put(dsc_send(command + '1' + data))
+					else:
+						writeQueueSer.put(dsc_send(command + data))
 				# Customizations
 				# - Change "arm stay" to "arm zero entry delay"
 				elif (command == COMMAND_PARTITION_ARM_CONTROL_STAY):


### PR DESCRIPTION
- PC5401 is the predecessor of IT-100 but it lacks some features.. The part of the protocol that is supported by PC5401 is nearly identical. So I think this would be also helpful for  PC5401 owners.
- The send PIN command works a bit differently on IT-100 and PC5401. 
- Some people might want to use  the Stay arm feature. So hard coding a remapping for zero entry delay is a bit nasty. I placed a configuration option for this. 
-Arming more the one  partitions should also work now, but it is not a perfect solution.